### PR TITLE
feat(home-media-chart): imagePullSecrets + per-release ServiceAccount (0.9.0)

### DIFF
--- a/charts/home-media-chart/Chart.yaml
+++ b/charts/home-media-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: home-media-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.8.0
+version: 0.9.0

--- a/charts/home-media-chart/README.md
+++ b/charts/home-media-chart/README.md
@@ -14,7 +14,7 @@ A Helm chart for Kubernetes
 | hostNetwork | bool | `false` | Host networking requested for this pod. Use the host's network namespace |
 | image.repository | string | `"nginx"` | Repository to use for the deployment |
 | image.tag | string | `""` | Image tag to use for the deployment |
-| imagePullSecrets | list | `[]` | Image pull secrets for pulling from private registries, e.g. [{name: ghcr-pull}] |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries, e.g. [{name: ghcr-pull}]. Attached to the created ServiceAccount (requires serviceAccount.create) |
 | ingress.annotations | object | `{}` | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata |
 | ingress.enabled | bool | `false` | Create an ingress object |
 | ingress.hosts | list | `[]` | A list of host rules used to configure the Ingress |

--- a/charts/home-media-chart/README.md
+++ b/charts/home-media-chart/README.md
@@ -29,7 +29,8 @@ A Helm chart for Kubernetes
 | service.ports | list | `[]` | The list of ports that are exposed by this service. Overwrites `service.port` and `service.targetPort` |
 | service.targetPort | string | `""` | Port to access on the pods targeted by the service. Has no effect if `service.ports` is configured |
 | service.type | string | `"ClusterIP"` | Determines how the Service is exposed |
-| serviceAccountName | string | `""` | Name of an existing ServiceAccount to run the pod under (empty uses the namespace default) |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount for the release (carries imagePullSecrets) |
+| serviceAccount.name | string | `""` | ServiceAccount name; defaults to the release name when empty |
 | startupProbe | object | `{}` | StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully |
 | volumeMounts | list | `[]` | Pod volumes to mount into the container's filesystem |
 | volumes | list | `[]` | List of volumes that can be mounted by containers belonging to the pod |

--- a/charts/home-media-chart/README.md
+++ b/charts/home-media-chart/README.md
@@ -1,6 +1,6 @@
 # home-media-chart
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -14,6 +14,7 @@ A Helm chart for Kubernetes
 | hostNetwork | bool | `false` | Host networking requested for this pod. Use the host's network namespace |
 | image.repository | string | `"nginx"` | Repository to use for the deployment |
 | image.tag | string | `""` | Image tag to use for the deployment |
+| imagePullSecrets | list | `[]` | Image pull secrets for pulling from private registries, e.g. [{name: ghcr-pull}] |
 | ingress.annotations | object | `{}` | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata |
 | ingress.enabled | bool | `false` | Create an ingress object |
 | ingress.hosts | list | `[]` | A list of host rules used to configure the Ingress |
@@ -28,6 +29,7 @@ A Helm chart for Kubernetes
 | service.ports | list | `[]` | The list of ports that are exposed by this service. Overwrites `service.port` and `service.targetPort` |
 | service.targetPort | string | `""` | Port to access on the pods targeted by the service. Has no effect if `service.ports` is configured |
 | service.type | string | `"ClusterIP"` | Determines how the Service is exposed |
+| serviceAccountName | string | `""` | Name of an existing ServiceAccount to run the pod under (empty uses the namespace default) |
 | startupProbe | object | `{}` | StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully |
 | volumeMounts | list | `[]` | Pod volumes to mount into the container's filesystem |
 | volumes | list | `[]` | List of volumes that can be mounted by containers belonging to the pod |

--- a/charts/home-media-chart/templates/_helpers.tpl
+++ b/charts/home-media-chart/templates/_helpers.tpl
@@ -40,3 +40,15 @@ Selector labels
 app.kubernetes.io/name: {{ include "home-helm-charts.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+ServiceAccount name. Defaults to the release name (fullname) when created and no
+explicit name is set; falls back to "default" when creation is disabled.
+*/}}
+{{- define "home-helm-charts.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "home-helm-charts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/home-media-chart/templates/deployment.yaml
+++ b/charts/home-media-chart/templates/deployment.yaml
@@ -16,9 +16,6 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:  {{- include "home-helm-charts.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets: {{- toYaml . | nindent 8 }}
-      {{- end }}
       serviceAccountName: {{ include "home-helm-charts.serviceAccountName" . }}
       containers:
       - name: {{ include "home-helm-charts.fullname" . }}

--- a/charts/home-media-chart/templates/deployment.yaml
+++ b/charts/home-media-chart/templates/deployment.yaml
@@ -16,6 +16,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:  {{- include "home-helm-charts.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       containers:
       - name: {{ include "home-helm-charts.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"

--- a/charts/home-media-chart/templates/deployment.yaml
+++ b/charts/home-media-chart/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.serviceAccountName }}
-      serviceAccountName: {{ . }}
-      {{- end }}
+      serviceAccountName: {{ include "home-helm-charts.serviceAccountName" . }}
       containers:
       - name: {{ include "home-helm-charts.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"

--- a/charts/home-media-chart/templates/serviceaccount.yaml
+++ b/charts/home-media-chart/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "home-helm-charts.serviceAccountName" . }}
+  labels: {{- include "home-helm-charts.labels" . | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets: {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/home-media-chart/values.yaml
+++ b/charts/home-media-chart/values.yaml
@@ -8,6 +8,12 @@ image:
   # -- Image tag to use for the deployment
   tag: ""
 
+# -- Image pull secrets for pulling from private registries, e.g. [{name: ghcr-pull}]
+imagePullSecrets: []
+
+# -- Name of an existing ServiceAccount to run the pod under (empty uses the namespace default)
+serviceAccountName: ""
+
 # -- The deployment strategy to use to replace existing pods with new ones
 rolloutStrategy: {}
 

--- a/charts/home-media-chart/values.yaml
+++ b/charts/home-media-chart/values.yaml
@@ -11,8 +11,11 @@ image:
 # -- Image pull secrets for pulling from private registries, e.g. [{name: ghcr-pull}]
 imagePullSecrets: []
 
-# -- Name of an existing ServiceAccount to run the pod under (empty uses the namespace default)
-serviceAccountName: ""
+serviceAccount:
+  # -- Create a ServiceAccount for the release (carries imagePullSecrets)
+  create: true
+  # -- ServiceAccount name; defaults to the release name when empty
+  name: ""
 
 # -- The deployment strategy to use to replace existing pods with new ones
 rolloutStrategy: {}

--- a/charts/home-media-chart/values.yaml
+++ b/charts/home-media-chart/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- Image tag to use for the deployment
   tag: ""
 
-# -- Image pull secrets for pulling from private registries, e.g. [{name: ghcr-pull}]
+# -- Image pull secrets for private registries, e.g. [{name: ghcr-pull}]. Attached to the created ServiceAccount (requires serviceAccount.create)
 imagePullSecrets: []
 
 serviceAccount:


### PR DESCRIPTION
Enables private-registry pulls and gives each release its own ServiceAccount.

## Changes (chart `0.8.0` → `0.9.0`)
- **ServiceAccount**: new `templates/serviceaccount.yaml`. `serviceAccount.create` (default **true**) makes a SA whose name defaults to the **release name** (`serviceAccount.name` overrides). The pod's `serviceAccountName` now always resolves to it (falls back to `default` when `create: false`).
- **imagePullSecrets**: new `imagePullSecrets` value, attached to the **ServiceAccount** (not the pod spec). Pods inherit it via the SA. Enables pulling private images (e.g. `ghcr.io/bryanhorstmann/rate-parity`).
- README values table regenerated (helm-docs); `Chart.yaml` bumped to `0.9.0`.

## Compatibility
Existing releases pin `version: "0.8.0"`, so publishing `0.9.0` doesn't touch them. On a future bump to `0.9.0` they gain a per-release SA (named after the release) with default RBAC — additive, no behaviour change for public images.

## Verified
- `helm template` (defaults): SA created, `serviceAccountName: <release>`, imagePullSecrets on the SA, **none** on the pod.
- `create: false`: no SA object, `serviceAccountName: default`.
- `helmlint` + `helm-docs` pre-commit pass.

On merge, chart-releaser publishes `home-media-chart-0.9.0`, which rate-parity#3 pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)